### PR TITLE
Feat: Separate box matching

### DIFF
--- a/python-sdk/nuscenes/eval/detection/algo.py
+++ b/python-sdk/nuscenes/eval/detection/algo.py
@@ -275,7 +275,6 @@ def accumulate(gt_boxes: EvalBoxes,
     # ---------------------------------------------
 
     # Accumulate.
-    stats = {"tp": tp, "fp": fp, "conf": conf, "match_data_before": copy.deepcopy(match_data)}
     tp = np.cumsum(tp).astype(float)
     fp = np.cumsum(fp).astype(float)
     conf = np.array(conf)
@@ -314,7 +313,7 @@ def accumulate(gt_boxes: EvalBoxes,
                                vel_err=match_data['vel_err'],
                                scale_err=match_data['scale_err'],
                                orient_err=match_data['orient_err'],
-                               attr_err=match_data['attr_err']), stats
+                               attr_err=match_data['attr_err'])
 
 
 def calc_ap(md: DetectionMetricData, min_recall: float, min_precision: float) -> float:

--- a/python-sdk/nuscenes/eval/detection/algo.py
+++ b/python-sdk/nuscenes/eval/detection/algo.py
@@ -81,10 +81,11 @@ def stats_from_matches(
         verbose: Optional[bool] = False
 ) -> DetectionMetricData:
     """
+    Computes the same stats as accumulate, but from matched boxes.
 
     :param matched_boxes:  The pre-matched boxes, generally from match_boxes
     :param class_name: Class to compute AP on.
-    :return:
+    :return: metrics. The raw data for a number of metrics.
     """
     # Count the positives.
     class_boxes = [box for box in matched_boxes if box.detection_name == class_name]

--- a/python-sdk/nuscenes/eval/detection/algo.py
+++ b/python-sdk/nuscenes/eval/detection/algo.py
@@ -59,7 +59,7 @@ def match_boxes(
                 raise ValueError("Specify either 'rel_dist_th' or 'dist_th'.")
             return is_match
 
-        if is_match(min_dist, gt_boxes[pred_box.sample_token][gt_idx]):
+        if is_match(min_dist, gt_boxes[pred_box.sample_token][gt_idx].translation[1]):
             taken.add((pred_box.sample_token, match_gt_idx))
             # Since it is a match, update match data also.
             gt_box_match = gt_boxes[pred_box.sample_token][match_gt_idx]

--- a/python-sdk/nuscenes/eval/detection/algo.py
+++ b/python-sdk/nuscenes/eval/detection/algo.py
@@ -1,13 +1,151 @@
 # nuScenes dev-kit.
 # Code written by Oscar Beijbom, 2019.
-
-from typing import Callable
+import copy
+from typing import Callable, List, Optional
 
 import numpy as np
 
 from nuscenes.eval.common.data_classes import EvalBoxes
 from nuscenes.eval.common.utils import center_distance, scale_iou, yaw_diff, velocity_l2, attr_acc, cummean
-from nuscenes.eval.detection.data_classes import DetectionMetricData
+from nuscenes.eval.detection.data_classes import DetectionMetricData, BoxMatch
+
+def match_boxes(
+        gt_boxes: EvalBoxes,
+        pred_boxes: EvalBoxes,
+        dist_fcn: Callable,
+        rel_dist_th: Optional[float] = None,
+        dist_th: Optional[float] = None,
+) -> List[BoxMatch]:
+    """
+    Matches prediction and GT boxes based on their distances.
+
+    :param gt_boxes: The GT boxes from the dataset
+    :param pred_boxes: The predicted boxes from the ego vehicle
+    :param dist_fcn: Distance function used to match detections and ground truths.
+    :param rel_dist_th: Relative distance threshold based on GT box depth for a match. Specify either this or rel_dist_th
+    :param dist_th: Distance threshold based on GT box depth for a match. Specify either this or dist_th.
+    :return: Matched boxes. These are matched based on both class name and distance.
+    """
+    assert (rel_dist_th is None) != (dist_th is None), "Specify exactly one of rel_dist_th or dist_th"
+    # Organize the predictions in a single list.
+    pred_confs = [box.detection_score for box in pred_boxes.all]
+
+    # Sort by confidence.
+    sortind = [i for (v, i) in sorted((v, i) for (i, v) in enumerate(pred_confs))][::-1]
+
+    matched_boxes = []
+    taken = set()  # Initially no gt bounding box is matched.
+    for ind in sortind:
+        pred_box = pred_boxes.all[ind]
+        min_dist = np.inf
+        match_gt_idx = None
+        for gt_idx, gt_box in enumerate(gt_boxes[pred_box.sample_token]):
+
+            # Find closest match among ground truth boxes
+            if gt_box.detection_name == pred_box.detection_name and not (pred_box.sample_token, gt_idx) in taken:
+                this_distance = dist_fcn(gt_box, pred_box)
+                if this_distance < min_dist:
+                    min_dist = this_distance
+                    match_gt_idx = gt_idx
+
+        # If the closest match is close enough according to threshold we have a match!
+        def is_match(proposal_dist, dist_to_ego):
+            if rel_dist_th is not None:
+                # Just using y distance, similar to the distance metrics
+                is_match = (match_gt_idx is not None) and (proposal_dist < (dist_to_ego * rel_dist_th) or proposal_dist < 0.25)
+            elif dist_th is not None:
+                is_match = proposal_dist < dist_th
+            else:
+                raise ValueError("Specify either 'rel_dist_th' or 'dist_th'.")
+            return is_match
+
+        if is_match(min_dist, gt_boxes[pred_box.sample_token][gt_idx]):
+            taken.add((pred_box.sample_token, match_gt_idx))
+            # Since it is a match, update match data also.
+            gt_box_match = gt_boxes[pred_box.sample_token][match_gt_idx]
+            matched_boxes.append(BoxMatch(gt_box_match, pred_box))
+        else:
+            matched_boxes.append(BoxMatch(None, pred_box))
+
+    # Populate with false negatives (missed detections)
+    for seq_key, sample_box_list in gt_boxes.boxes.items():
+        for gt_idx, gt_box in enumerate(sample_box_list):
+            if (gt_box.sample_token, gt_idx) not in taken:
+                matched_boxes.append(BoxMatch(gt_box, None))
+    return matched_boxes
+
+
+def stats_from_matches(
+        matched_boxes: List[BoxMatch],
+        class_name: str,
+        verbose: Optional[bool] = False
+) -> DetectionMetricData:
+    """
+
+    :param matched_boxes:  The pre-matched boxes, generally from match_boxes
+    :param class_name: Class to compute AP on.
+    :return:
+    """
+    # Count the positives.
+    class_boxes = [box for box in matched_boxes if box.detection_name == class_name]
+    npos = sum([box.has_gt for box in class_boxes])
+    if verbose:
+        print("Found {} GT of class {} out of {}.".
+              format(npos, class_name, len(matched_boxes)))
+    class_pred_boxes = [box for box in matched_boxes if box.has_pred]
+    # For missing classes in the GT, return a data structure corresponding to no predictions.
+    if npos == 0:
+        return DetectionMetricData.no_predictions()
+
+    # If we have no detections, return an empty prediction.
+    if not any(box.has_pred for box in class_pred_boxes):
+        return DetectionMetricData.no_predictions()
+
+    matched_tps = [box for box in class_pred_boxes if box.tp]
+    period = np.pi if class_name == 'barrier' else 2 * np.pi
+
+    match_data = {'trans_err': [center_distance(match.gt, match.pred) for match in matched_tps],
+                  'vel_err': [velocity_l2(match.gt, match.pred) for match in matched_tps],
+                  'scale_err': [1 - scale_iou(match.gt, match.pred) for match in matched_tps],
+                  'orient_err': [yaw_diff(match.gt, match.pred, period=period) for match in matched_tps],
+                  'attr_err': [1 - attr_acc(match.gt, match.pred) for match in matched_tps],
+                  'conf': [box.detection_score for box in matched_tps]}
+
+    tp = np.cumsum([box.tp for box in class_pred_boxes]).astype(float)
+    fp = np.cumsum([box.fp for box in class_pred_boxes]).astype(float)
+    conf = np.array([box.detection_score for box in class_pred_boxes])
+
+    # Calculate precision and recall.
+    prec = tp / (fp + tp)
+    rec = tp / float(npos)
+
+    rec_interp = np.linspace(0, 1, DetectionMetricData.nelem)  # 101 steps, from 0% to 100% recall.
+    prec = np.interp(rec_interp, rec, prec, right=0)
+    conf = np.interp(rec_interp, rec, conf, right=0)
+    rec = rec_interp
+
+    for key in match_data.keys():
+        if key == "conf":
+            continue  # Confidence is used as reference to align with fp and tp. So skip in this step.
+
+        else:
+            # For each match_data, we first calculate the accumulated mean.
+            tmp = cummean(np.array(match_data[key]))
+
+            # Then interpolate based on the confidences. (Note reversing since np.interp needs increasing arrays)
+            match_data[key] = np.interp(conf[::-1], match_data['conf'][::-1], tmp[::-1])[::-1]
+
+    # ---------------------------------------------
+    # Done. Instantiate MetricData and return
+    # ---------------------------------------------
+    return DetectionMetricData(recall=rec,
+                               precision=prec,
+                               confidence=conf,
+                               trans_err=match_data['trans_err'],
+                               vel_err=match_data['vel_err'],
+                               scale_err=match_data['scale_err'],
+                               orient_err=match_data['orient_err'],
+                               attr_err=match_data['attr_err'])
 
 
 def accumulate(gt_boxes: EvalBoxes,
@@ -34,7 +172,6 @@ def accumulate(gt_boxes: EvalBoxes,
     # ---------------------------------------------
 
     assert ~((rel_dist_th is not None) and (dist_fcn is not None))
-
     # Count the positives.
     npos = len([1 for gt_box in gt_boxes.all if gt_box.detection_name == class_name])
     if verbose:
@@ -138,6 +275,7 @@ def accumulate(gt_boxes: EvalBoxes,
     # ---------------------------------------------
 
     # Accumulate.
+    stats = {"tp": tp, "fp": fp, "conf": conf, "match_data_before": copy.deepcopy(match_data)}
     tp = np.cumsum(tp).astype(float)
     fp = np.cumsum(fp).astype(float)
     conf = np.array(conf)
@@ -176,7 +314,7 @@ def accumulate(gt_boxes: EvalBoxes,
                                vel_err=match_data['vel_err'],
                                scale_err=match_data['scale_err'],
                                orient_err=match_data['orient_err'],
-                               attr_err=match_data['attr_err'])
+                               attr_err=match_data['attr_err']), stats
 
 
 def calc_ap(md: DetectionMetricData, min_recall: float, min_precision: float) -> float:

--- a/python-sdk/nuscenes/eval/detection/data_classes.py
+++ b/python-sdk/nuscenes/eval/detection/data_classes.py
@@ -144,7 +144,7 @@ class BoxMatch:
         else:
             raise ValueError("Both gt and pred are None.")
 
-        return chosen.translation[:1]
+        return chosen.translation[1]
 
 
 

--- a/python-sdk/nuscenes/eval/detection/data_classes.py
+++ b/python-sdk/nuscenes/eval/detection/data_classes.py
@@ -1,14 +1,151 @@
 # nuScenes dev-kit.
 # Code written by Oscar Beijbom, 2019.
-
+import dataclasses
 from collections import defaultdict
-from typing import List, Dict, Tuple
+from typing import List, Dict, Tuple, Optional
 
 import numpy as np
 
 from nuscenes.eval.common.data_classes import MetricData, EvalBox
 from nuscenes.eval.common.utils import center_distance
 from nuscenes.eval.detection.constants import DETECTION_NAMES, ATTRIBUTE_NAMES, TP_METRICS
+
+class DetectionBox(EvalBox):
+    """ Data class used during detection evaluation. Can be a prediction or ground truth."""
+
+    def __init__(self,
+                 sample_token: str = "",
+                 translation: Tuple[float, float, float] = (0, 0, 0),
+                 size: Tuple[float, float, float] = (0, 0, 0),
+                 rotation: Tuple[float, float, float, float] = (0, 0, 0, 0),
+                 velocity: Tuple[float, float] = (0, 0),
+                 ego_translation: [float, float, float] = (0, 0, 0),  # Translation to ego vehicle in meters.
+                 num_pts: int = -1,  # Nbr. LIDAR or RADAR inside the box. Only for gt boxes.
+                 detection_name: str = 'car',  # The class name used in the detection challenge.
+                 detection_score: float = -1.0,  # GT samples do not have a score.
+                 attribute_name: str = ''):  # Box attribute. Each box can have at most 1 attribute.
+
+        super().__init__(sample_token, translation, size, rotation, velocity, ego_translation, num_pts)
+
+        assert detection_name is not None, 'Error: detection_name cannot be empty!'
+        assert detection_name in DETECTION_NAMES, 'Error: Unknown detection_name %s' % detection_name
+
+        assert attribute_name in ATTRIBUTE_NAMES or attribute_name == '', \
+            'Error: Unknown attribute_name %s' % attribute_name
+
+        assert type(detection_score) == float, 'Error: detection_score must be a float!'
+        assert not np.any(np.isnan(detection_score)), 'Error: detection_score may not be NaN!'
+
+        # Assign.
+        self.detection_name = detection_name
+        self.detection_score = detection_score
+        self.attribute_name = attribute_name
+
+    def __eq__(self, other):
+        return (self.sample_token == other.sample_token and
+                self.translation == other.translation and
+                self.size == other.size and
+                self.rotation == other.rotation and
+                self.velocity == other.velocity and
+                self.ego_translation == other.ego_translation and
+                self.num_pts == other.num_pts and
+                self.detection_name == other.detection_name and
+                self.detection_score == other.detection_score and
+                self.attribute_name == other.attribute_name)
+
+    def serialize(self) -> dict:
+        """ Serialize instance into json-friendly format. """
+        return {
+            'sample_token': self.sample_token,
+            'translation': self.translation,
+            'size': self.size,
+            'rotation': self.rotation,
+            'velocity': self.velocity,
+            'ego_translation': self.ego_translation,
+            'num_pts': self.num_pts,
+            'detection_name': self.detection_name,
+            'detection_score': self.detection_score,
+            'attribute_name': self.attribute_name
+        }
+
+    @classmethod
+    def deserialize(cls, content: dict):
+        """ Initialize from serialized content. """
+        return cls(sample_token=content['sample_token'],
+                   translation=tuple(content['translation']),
+                   size=tuple(content['size']),
+                   rotation=tuple(content['rotation']),
+                   velocity=tuple(content['velocity']),
+                   ego_translation=(0.0, 0.0, 0.0) if 'ego_translation' not in content
+                   else tuple(content['ego_translation']),
+                   num_pts=-1 if 'num_pts' not in content else int(content['num_pts']),
+                   detection_name=content['detection_name'],
+                   detection_score=-1.0 if 'detection_score' not in content else float(content['detection_score']),
+                   attribute_name=content['attribute_name'])
+
+
+@dataclasses.dataclass
+class BoxMatch:
+    """
+    Represents a matching between a gt and a pred DetectionBox.
+
+    Either of these might be None, representing FP/FN detections.
+    """
+
+    gt: Optional[DetectionBox]
+    pred: Optional[DetectionBox]
+
+    @property
+    def detection_name(self) -> str:
+        """Gives the class name of this detection match."""
+        if self.has_gt:
+            return self.gt.detection_name
+        return self.pred.detection_name
+
+    @property
+    def detection_score(self) -> float:
+        """Gives the class name of this detection match."""
+        if self.has_pred:
+            return self.pred.detection_score
+        return 0.0
+
+    @property
+    def has_gt(self) -> bool:
+        """Indicator on whether this has a GT."""
+        return self.gt is not None
+
+    @property
+    def has_pred(self) -> bool:
+        """Indicator on whether this has a Pred."""
+        return self.pred is not None
+
+    @property
+    def tp(self) -> bool:
+        """Is true positive."""
+        return self.has_gt and self.has_pred
+
+    @property
+    def fp(self) -> bool:
+        """Is false positive."""
+        return not self.has_gt and self.has_pred
+
+    @property
+    def fn(self) -> bool:
+        """Is false negative."""
+        return self.has_gt and not self.has_pred
+
+    def distance_to_ego(self):
+        """Computes the distance to the ego vehicle."""
+
+        if self.gt is not None:
+            chosen = self.gt
+        elif self.pred is not None:
+            chosen = self.pred
+        else:
+            raise ValueError("Both gt and pred are None.")
+
+        return chosen.translation[:1]
+
 
 
 class DetectionConfig:
@@ -91,7 +228,8 @@ class DetectionMetricData(MetricData):
                  vel_err: np.array,
                  scale_err: np.array,
                  orient_err: np.array,
-                 attr_err: np.array):
+                 attr_err: np.array,
+                 ):
 
         # Assert lengths.
         assert len(recall) == self.nelem
@@ -312,78 +450,6 @@ class DetectionMetrics:
         return eq
 
 
-class DetectionBox(EvalBox):
-    """ Data class used during detection evaluation. Can be a prediction or ground truth."""
-
-    def __init__(self,
-                 sample_token: str = "",
-                 translation: Tuple[float, float, float] = (0, 0, 0),
-                 size: Tuple[float, float, float] = (0, 0, 0),
-                 rotation: Tuple[float, float, float, float] = (0, 0, 0, 0),
-                 velocity: Tuple[float, float] = (0, 0),
-                 ego_translation: [float, float, float] = (0, 0, 0),  # Translation to ego vehicle in meters.
-                 num_pts: int = -1,  # Nbr. LIDAR or RADAR inside the box. Only for gt boxes.
-                 detection_name: str = 'car',  # The class name used in the detection challenge.
-                 detection_score: float = -1.0,  # GT samples do not have a score.
-                 attribute_name: str = ''):  # Box attribute. Each box can have at most 1 attribute.
-
-        super().__init__(sample_token, translation, size, rotation, velocity, ego_translation, num_pts)
-
-        assert detection_name is not None, 'Error: detection_name cannot be empty!'
-        assert detection_name in DETECTION_NAMES, 'Error: Unknown detection_name %s' % detection_name
-
-        assert attribute_name in ATTRIBUTE_NAMES or attribute_name == '', \
-            'Error: Unknown attribute_name %s' % attribute_name
-
-        assert type(detection_score) == float, 'Error: detection_score must be a float!'
-        assert not np.any(np.isnan(detection_score)), 'Error: detection_score may not be NaN!'
-
-        # Assign.
-        self.detection_name = detection_name
-        self.detection_score = detection_score
-        self.attribute_name = attribute_name
-
-    def __eq__(self, other):
-        return (self.sample_token == other.sample_token and
-                self.translation == other.translation and
-                self.size == other.size and
-                self.rotation == other.rotation and
-                self.velocity == other.velocity and
-                self.ego_translation == other.ego_translation and
-                self.num_pts == other.num_pts and
-                self.detection_name == other.detection_name and
-                self.detection_score == other.detection_score and
-                self.attribute_name == other.attribute_name)
-
-    def serialize(self) -> dict:
-        """ Serialize instance into json-friendly format. """
-        return {
-            'sample_token': self.sample_token,
-            'translation': self.translation,
-            'size': self.size,
-            'rotation': self.rotation,
-            'velocity': self.velocity,
-            'ego_translation': self.ego_translation,
-            'num_pts': self.num_pts,
-            'detection_name': self.detection_name,
-            'detection_score': self.detection_score,
-            'attribute_name': self.attribute_name
-        }
-
-    @classmethod
-    def deserialize(cls, content: dict):
-        """ Initialize from serialized content. """
-        return cls(sample_token=content['sample_token'],
-                   translation=tuple(content['translation']),
-                   size=tuple(content['size']),
-                   rotation=tuple(content['rotation']),
-                   velocity=tuple(content['velocity']),
-                   ego_translation=(0.0, 0.0, 0.0) if 'ego_translation' not in content
-                   else tuple(content['ego_translation']),
-                   num_pts=-1 if 'num_pts' not in content else int(content['num_pts']),
-                   detection_name=content['detection_name'],
-                   detection_score=-1.0 if 'detection_score' not in content else float(content['detection_score']),
-                   attribute_name=content['attribute_name'])
 
 
 class DetectionMetricDataList:

--- a/python-sdk/nuscenes/eval/detection/evaluate_wrapper.py
+++ b/python-sdk/nuscenes/eval/detection/evaluate_wrapper.py
@@ -109,7 +109,8 @@ class DetectionEvalWrapper:
             print('Accumulating metric data...')
         metric_data_list = DetectionMetricDataList()
         for rel_dist_th in rel_dist_ths_:
-            matches = match_boxes(gt_boxes, pred_boxes, dist_fcn=center_distance, rel_dist_th=rel_dist_th)
+            matches = match_boxes(gt_boxes, pred_boxes, dist_fcn=center_distance, rel_dist_th=rel_dist_th,
+                                  dist_th=0.25)
             for class_name in self.cfg.class_names:
                 md = stats_from_matches(matches, class_name)
                 metric_data_list.set(class_name, rel_dist_th, md)

--- a/python-sdk/nuscenes/eval/detection/evaluate_wrapper.py
+++ b/python-sdk/nuscenes/eval/detection/evaluate_wrapper.py
@@ -11,6 +11,7 @@ import os
 
 from nuscenes.eval.common.data_classes import EvalBoxes
 from nuscenes.eval.detection.algo import calc_ap, calc_tp, match_boxes, stats_from_matches
+from nuscenes.eval.common.utils import center_distance
 from nuscenes.eval.detection.constants import TP_METRICS, DETECTION_NAMES
 from nuscenes.eval.detection.data_classes import DetectionConfig, DetectionMetrics, DetectionBox, \
     DetectionMetricDataList
@@ -108,7 +109,7 @@ class DetectionEvalWrapper:
             print('Accumulating metric data...')
         metric_data_list = DetectionMetricDataList()
         for rel_dist_th in rel_dist_ths_:
-            matches = match_boxes(gt_boxes, pred_boxes, rel_dist_th=rel_dist_th)
+            matches = match_boxes(gt_boxes, pred_boxes, dist_fcn=center_distance, rel_dist_th=rel_dist_th)
             for class_name in self.cfg.class_names:
                 md = stats_from_matches(matches, class_name)
                 metric_data_list.set(class_name, rel_dist_th, md)

--- a/python-sdk/nuscenes/eval/detection/evaluate_wrapper.py
+++ b/python-sdk/nuscenes/eval/detection/evaluate_wrapper.py
@@ -10,7 +10,7 @@ from copy import deepcopy
 import os
 
 from nuscenes.eval.common.data_classes import EvalBoxes
-from nuscenes.eval.detection.algo import accumulate, calc_ap, calc_tp
+from nuscenes.eval.detection.algo import calc_ap, calc_tp, match_boxes, stats_from_matches
 from nuscenes.eval.detection.constants import TP_METRICS, DETECTION_NAMES
 from nuscenes.eval.detection.data_classes import DetectionConfig, DetectionMetrics, DetectionBox, \
     DetectionMetricDataList
@@ -107,9 +107,10 @@ class DetectionEvalWrapper:
         if self.verbose:
             print('Accumulating metric data...')
         metric_data_list = DetectionMetricDataList()
-        for class_name in self.cfg.class_names:
-            for rel_dist_th in rel_dist_ths_:
-                md = accumulate(gt_boxes, pred_boxes, class_name, self.cfg.dist_fcn_callable, rel_dist_th)
+        for rel_dist_th in rel_dist_ths_:
+            matches = match_boxes(gt_boxes, pred_boxes, rel_dist_th=rel_dist_th)
+            for class_name in self.cfg.class_names:
+                md = stats_from_matches(matches, class_name)
                 metric_data_list.set(class_name, rel_dist_th, md)
 
         # -----------------------------------

--- a/python-sdk/nuscenes/eval/detection/tests/test_algo.py
+++ b/python-sdk/nuscenes/eval/detection/tests/test_algo.py
@@ -95,7 +95,7 @@ class TestAlgo(unittest.TestCase):
             gt, pred = self._mock_results(30, 3, 25, class_name)
             for dist_th in self.cfg.dist_ths:
                 acc = accumulate(gt, pred, class_name, center_distance, dist_th=dist_th)
-                matches = match_boxes(gt, pred, dist_th=dist_th)
+                matches = match_boxes(gt, pred, dist_th=dist_th, dist_fcn=center_distance)
                 new_acc = stats_from_matches(matches, class_name)
                 for name in ["attr_err", "confidence",
                              "orient_err", "precision", "recall", "scale_err",

--- a/python-sdk/nuscenes/eval/detection/tests/test_algo.py
+++ b/python-sdk/nuscenes/eval/detection/tests/test_algo.py
@@ -11,7 +11,7 @@ from pyquaternion import Quaternion
 from nuscenes.eval.common.config import config_factory
 from nuscenes.eval.common.data_classes import EvalBoxes
 from nuscenes.eval.common.utils import center_distance
-from nuscenes.eval.detection.algo import accumulate, calc_ap, calc_tp
+from nuscenes.eval.detection.algo import accumulate, calc_ap, calc_tp, match_boxes, stats_from_matches
 from nuscenes.eval.detection.constants import TP_METRICS
 from nuscenes.eval.detection.data_classes import DetectionMetrics, DetectionMetricData, DetectionBox, \
     DetectionMetricDataList
@@ -82,6 +82,28 @@ class TestAlgo(unittest.TestCase):
             pred.add_boxes(str(sample_itt), this_pred)
 
         return gt, pred
+
+    def test_equivalency(self):
+        """
+        This tests runs tests the equivalency of the match_boxes and the NuScenes code.
+        """
+
+        random.seed(42)
+        np.random.seed(42)
+
+        for class_name in self.cfg.class_names:
+            gt, pred = self._mock_results(30, 3, 25, class_name)
+            for dist_th in self.cfg.dist_ths:
+                acc = accumulate(gt, pred, class_name, center_distance, dist_th=dist_th)
+                matches = match_boxes(gt, pred, dist_th=dist_th)
+                new_acc = stats_from_matches(matches, class_name)
+                for name in ["attr_err", "confidence",
+                             "orient_err", "precision", "recall", "scale_err",
+                             "trans_err", "vel_err"]:
+                    diff = np.sum(np.abs(getattr(acc, name) - getattr(new_acc, name)))
+                    self.assertAlmostEqual(diff, 0.0, msg=(class_name, dist_th, name))
+                for name in ["max_recall", "max_recall_ind", "nelem"]:
+                    self.assertEqual(getattr(acc, name), getattr(new_acc, name), msg=(class_name, dist_th, name))
 
     def test_nd_score(self):
         """


### PR DESCRIPTION
This separates out box matching from accumulation.

In the original code, both happens within the accumulate function. However, to reuse the code for the detailed metrics, I've pulled out the matching into a separate function. `test_equivalency` ensures both produce the same result.

Tagging @al093 to get notified after his vacation.