### PR TITLE
warn when there are no predictions, don't raise

### DIFF
--- a/python-sdk/nuscenes/eval/common/loaders.py
+++ b/python-sdk/nuscenes/eval/common/loaders.py
@@ -208,17 +208,16 @@ def add_center_dist(nusc: NuScenes,
 def filter_eval_boxes(nusc: NuScenes,
                       eval_boxes: EvalBoxes,
                       max_dist: Dict[str, float],
+                      class_field: str,
                       verbose: bool = False) -> EvalBoxes:
     """
     Applies filtering to boxes. Distance, bike-racks and points per box.
     :param nusc: An instance of the NuScenes class.
     :param eval_boxes: An instance of the EvalBoxes class.
     :param max_dist: Maps the detection name to the eval distance threshold for that class.
+    :param class_field: One of ``tracking_name`` or ``detection_name``
     :param verbose: Whether to print to stdout.
     """
-    # Retrieve box type for detectipn/tracking boxes.
-    class_field = _get_box_class_field(eval_boxes)
-
     # Accumulators for number of filtered boxes.
     total, dist_filter, point_filter, bike_rack_filter = 0, 0, 0, 0
     for ind, sample_token in enumerate(eval_boxes.sample_tokens):
@@ -260,27 +259,3 @@ def filter_eval_boxes(nusc: NuScenes,
         print("=> After bike rack filtering: %d" % bike_rack_filter)
 
     return eval_boxes
-
-
-def _get_box_class_field(eval_boxes: EvalBoxes) -> str:
-    """
-    Retrieve the name of the class field in the boxes.
-    This parses through all boxes until it finds a valid box.
-    If there are no valid boxes, this function throws an exception.
-    :param eval_boxes: The EvalBoxes used for evaluation.
-    :return: The name of the class field in the boxes, e.g. detection_name or tracking_name.
-    """
-    assert len(eval_boxes.boxes) > 0
-    box = None
-    for val in eval_boxes.boxes.values():
-        if len(val) > 0:
-            box = val[0]
-            break
-    if isinstance(box, DetectionBox):
-        class_field = 'detection_name'
-    elif isinstance(box, TrackingBox):
-        class_field = 'tracking_name'
-    else:
-        raise Exception('Error: Invalid box type: %s' % box)
-
-    return class_field

--- a/python-sdk/nuscenes/eval/common/loaders.py
+++ b/python-sdk/nuscenes/eval/common/loaders.py
@@ -215,7 +215,8 @@ def filter_eval_boxes(nusc: NuScenes,
     :param nusc: An instance of the NuScenes class.
     :param eval_boxes: An instance of the EvalBoxes class.
     :param max_dist: Maps the detection name to the eval distance threshold for that class.
-    :param class_field: One of ``tracking_name`` or ``detection_name``
+    :param class_field: One of "tracking_name" when you feed ``eval_boxes`` of type ``TrackingBox`` or
+                        "detection_name" when you feed ``eval_boxes`` of type ``DetectionBox``.
     :param verbose: Whether to print to stdout.
     """
     # Accumulators for number of filtered boxes.

--- a/python-sdk/nuscenes/eval/detection/algo.py
+++ b/python-sdk/nuscenes/eval/detection/algo.py
@@ -1,6 +1,6 @@
 # nuScenes dev-kit.
 # Code written by Oscar Beijbom, 2019.
-
+import logging
 from typing import Callable
 
 import numpy as np
@@ -43,6 +43,8 @@ def accumulate(gt_boxes: EvalBoxes,
 
     # Organize the predictions in a single list.
     pred_boxes_list = [box for box in pred_boxes.all if box.detection_name == class_name]
+    if not pred_boxes_list:
+        logging.warning(f"There are no predictions for class {class_name}")
     pred_confs = [box.detection_score for box in pred_boxes_list]
 
     if verbose:

--- a/python-sdk/nuscenes/eval/detection/evaluate.py
+++ b/python-sdk/nuscenes/eval/detection/evaluate.py
@@ -101,7 +101,6 @@ class DetectionEval:
             assert self.pred_boxes.all, f"there are no pred_boxes after load_prediction() from {self.result_path=}"
         elif result is not None:
             self.pred_boxes = result
-            assert self.pred_boxes.all, "there are no pred_boxes in `result`"
         else:
             raise ValueError("need to either specify `result_path` or pass predicted boxes via `result` argument")
 
@@ -130,11 +129,10 @@ class DetectionEval:
         # Filter boxes (distance, points per box, etc.).
         if verbose:
             print('Filtering predictions')
-        self.pred_boxes = filter_eval_boxes(nusc, self.pred_boxes, self.cfg.class_range, verbose=verbose)
-        assert self.pred_boxes.all, f"there are no pred_boxes after filter_eval_boxes() with {self.cfg.class_range=}"
+        self.pred_boxes = filter_eval_boxes(nusc, self.pred_boxes, self.cfg.class_range, class_field="detection_name", verbose=verbose)
         if verbose:
             print('Filtering ground truth annotations')
-        self.gt_boxes = filter_eval_boxes(nusc, self.gt_boxes, self.cfg.class_range, verbose=verbose)
+        self.gt_boxes = filter_eval_boxes(nusc, self.gt_boxes, self.cfg.class_range, class_field="detection_name", verbose=verbose)
         assert self.gt_boxes.all, f"there are no gt_boxes after filter_eval_boxes() with {self.cfg.class_range=}"
         self.sample_tokens = self.gt_boxes.sample_tokens
 


### PR DESCRIPTION
title says it all. 
```
WARNING  root:algo.py:47 There are no predictions for class car
```
> 	 Eval metrics/eval/nuscenes_metric: { "mAP": 0.0000, "NDS": 0.0000, "mATE": 1.0000, "mASE": 1.0000, "mAOE": 1.0000, "mAVE": 1.0000, "mAAE": 1.0000, "car/mAP": 0.0000, "truck/mAP": 0.0000, "bus/mAP": 0.0000, "trailer/mAP": 0.0000, "construction_vehicle/mAP": 0.0000, "pedestrian/mAP": 0.0000, "motorcycle/mAP": 0.0000, "bicycle/mAP": 0.0000, "traffic_cone/mAP": 0.0000, "barrier/mAP": 0.0000, "num_samples": 4, }

