### PR TITLE
Re-do: Remove matplotlib version constrain

### DIFF
--- a/requirements/requirements_base.txt
+++ b/requirements/requirements_base.txt
@@ -1,7 +1,7 @@
 cachetools
 descartes
 fire
-matplotlib<3.6.0
+matplotlib
 numpy>=1.22.0
 opencv-python>=4.5.4.58
 Pillow>6.2.1


### PR DESCRIPTION
This is a copy of #9 on the public master instead of on outdated internal fork of master. The outdated internal master caused issues with BEV former benchmarks.